### PR TITLE
Remove "translations.xml" checking from pisi

### DIFF
--- a/pisi/constants.py
+++ b/pisi/constants.py
@@ -85,7 +85,6 @@ class Constants:
         self.__c.pspec_file = "pspec.xml"
         self.__c.files_dir = "files"
         self.__c.metadata_dir = "metadata"
-        self.__c.translations_file = "translations.xml"
         self.__c.comar_dir = "comar"
         self.__c.files_xml = "files.xml"
         self.__c.metadata_xml = "metadata.xml"

--- a/pisi/operations/build.py
+++ b/pisi/operations/build.py
@@ -280,8 +280,6 @@ class Builder:
         self.target_package_format = ctx.get_option("package_format") \
                                         or pisi.package.Package.default_format
 
-        self.read_translations(self.specdir)
-
         self.sourceArchives = pisi.sourcearchive.SourceArchives(self.spec)
 
         self.build_types = self.get_build_types()
@@ -313,10 +311,6 @@ class Builder:
         spec = pisi.specfile.SpecFile()
         spec.read(self.specuri, ctx.config.tmp_dir())
         self.spec = spec
-
-    def read_translations(self, specdir):
-        self.spec.read_translations(util.join_path(specdir,
-                                    ctx.const.translations_file))
 
     def package_filename(self, package_info, release_info=None,
                          distro_id=None, with_extension=True):
@@ -486,7 +480,6 @@ class Builder:
 
         self.fetch_actionsfile()
         self.check_build_dependencies()
-        self.fetch_translationsfile()
         self.fetch_patches()
         self.fetch_comarfiles()
         self.fetch_additionalFiles()
@@ -500,15 +493,6 @@ class Builder:
     def fetch_actionsfile(self):
         actionsuri = util.join_path(self.specdiruri, ctx.const.actions_file)
         self.download(actionsuri, self.destdir)
-
-    def fetch_translationsfile(self):
-        translationsuri = util.join_path(self.specdiruri,
-                                         ctx.const.translations_file)
-        try:
-            self.download(translationsuri, self.destdir)
-        except pisi.fetcher.FetchError:
-            # translations.xml is not mandatory for eopkg
-            pass
 
     def fetch_patches(self):
         for patch in self.spec.source.patches:


### PR DESCRIPTION
Ever since the retry mechanism was added to pisi/eopkg the install steps for a third party package lead to the following errors:

```
Failed to fetch file, retrying 1 out of 5 "https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-stable/translations.xml": HTTP Error 404: Not Found

Failed to fetch file, retrying 2 out of 5 "https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-stable/translations.xml": HTTP Error 404: Not Found

Failed to fetch file, retrying 3 out of 5 "https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-stable/translations.xml": HTTP Error 404: Not Found

Failed to fetch file, retrying 4 out of 5 "https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-stable/translations.xml": HTTP Error 404: Not Found

Failed to fetch file, retrying 5 out of 5 "https://raw.githubusercontent.com/getsolus/3rd-party/master/network/web/browser/google-chrome-stable/translations.xml": HTTP Error 404: Not Found
```

Since this is both confusing to the user, and completely unnecessary (as we don't use this file anywhere AFAICT), this PR removes the "translations.xml" checks from pisi.