### PR TITLE
Make standard C(XX)FLAGS more robust

### DIFF
--- a/pisi/configfile.py
+++ b/pisi/configfile.py
@@ -86,8 +86,8 @@ class BuildDefaults:
     jobs = "auto"
     generateDebug = False
     enableSandbox = False # Dropping sandbox support soon
-    cflags = "-mtune=generic -march=x86-64 -g2 -O2 -pipe -fPIC -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param ssp-buffer-size=32 -fasynchronous-unwind-tables -ftree-vectorize -feliminate-unused-debug-types -Wall -Wno-error -Wp,-D_REENTRANT"
-    cxxflags = "-mtune=generic -march=x86-64 -g2 -O2 -pipe -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param ssp-buffer-size=32 -fasynchronous-unwind-tables -ftree-vectorize -feliminate-unused-debug-types -Wall -Wno-error -Wp,-D_REENTRANT"
+    cflags = "-mtune=generic -march=x86-64 -g2 -O2 -pipe -fPIC -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param=ssp-buffer-size=32 -fasynchronous-unwind-tables -ftree-vectorize -feliminate-unused-debug-types -Wall -Wno-error -Wp,-D_REENTRANT"
+    cxxflags = "-mtune=generic -march=x86-64 -g2 -O2 -pipe -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param=ssp-buffer-size=32 -fasynchronous-unwind-tables -ftree-vectorize -feliminate-unused-debug-types -Wall -Wno-error -Wp,-D_REENTRANT"
     ldflags = "-Wl,--copy-dt-needed-entries -Wl,-O1 -Wl,-z,relro -Wl,-z,now -Wl,-z,max-page-size=0x1000 -Wl,-Bsymbolic-functions -Wl,--sort-common"
     buildhelper = "ccache"
     compressionlevel = 1


### PR DESCRIPTION
> This changes `--param ssp-buffer-size=32` into `--param=ssp-buffer-size=32` (with a connecting equals sign).
> Some configure scripts seem to have a problem with the space in between.

We previously included this patch directly with our Solus package, but it got swept up in the huge patch removal after the recent new tagged release, and I never actually submitted it as a PR before.
More details see [here](https://dev.getsol.us/D8797)
While `anki` no longer seems to suffer from this particular issue, it might pop up somewhere else in the future (or in a rebuild of a currently available package).

P.S. This also matches [the way Ubuntu formats the flag now](https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-fstack-protector-strong_--param.3Dssp-buffer-size.3D4)