### PR TITLE
Dedupe locale usage; follow the LANG variable

### DIFF
--- a/eopkg-cli
+++ b/eopkg-cli
@@ -20,11 +20,7 @@ import pisi
 import pisi.context as ctx
 import pisi.cli.pisicli as pisicli
 
-import gettext
-gettext.bindtextdomain('pisi', "/usr/share/locale")
-gettext.textdomain('pisi')
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 def sig_handler(sig, frame):
     if sig == signal.SIGTERM:

--- a/pisi/__init__.py
+++ b/pisi/__init__.py
@@ -18,6 +18,12 @@ import atexit
 import logging
 import logging.handlers
 
+import locale
+import gettext
+locale.setlocale(locale.LC_ALL, '')
+# You usually want to import this function with the "_" alias.
+translate = gettext.translation('pisi', languages=[locale.getlocale()[0]], fallback=True).ugettext
+
 __version__ = "3.2"
 
 __all__ = [ 'api', 'configfile', 'db']

--- a/pisi/actionsapi/autotools.py
+++ b/pisi/actionsapi/autotools.py
@@ -12,9 +12,7 @@
 # Standard Python Modules
 import os
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/cmaketools.py
+++ b/pisi/actionsapi/cmaketools.py
@@ -12,9 +12,7 @@
 # Standard Python Modules
 import os
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/get.py
+++ b/pisi/actionsapi/get.py
@@ -13,9 +13,7 @@
 import os
 import sys
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # eopkg Modules
 import pisi.actionsapi

--- a/pisi/actionsapi/kde.py
+++ b/pisi/actionsapi/kde.py
@@ -12,9 +12,7 @@
 # standard python modules
 import os
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/kerneltools.py
+++ b/pisi/actionsapi/kerneltools.py
@@ -14,9 +14,7 @@ import os
 import re
 import shutil
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/libtools.py
+++ b/pisi/actionsapi/libtools.py
@@ -12,9 +12,7 @@
 # Standard Python Modules
 import os
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi-Core Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/perlmodules.py
+++ b/pisi/actionsapi/perlmodules.py
@@ -13,9 +13,7 @@
 import os
 import glob
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/pisitools.py
+++ b/pisi/actionsapi/pisitools.py
@@ -20,9 +20,7 @@ import fileinput
 import re
 import filecmp
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/pisitoolsfunctions.py
+++ b/pisi/actionsapi/pisitoolsfunctions.py
@@ -15,9 +15,7 @@
 import os
 import glob
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/pythonmodules.py
+++ b/pisi/actionsapi/pythonmodules.py
@@ -13,9 +13,7 @@
 import os
 import glob
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/qt4.py
+++ b/pisi/actionsapi/qt4.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 
 import glob
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/scons.py
+++ b/pisi/actionsapi/scons.py
@@ -13,9 +13,7 @@
 # Pisi Modules
 import pisi.context as ctx
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # ActionsAPI Modules
 import pisi.actionsapi

--- a/pisi/actionsapi/shelltools.py
+++ b/pisi/actionsapi/shelltools.py
@@ -17,9 +17,7 @@ import string
 import pwd
 import grp
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/texlivemodules.py
+++ b/pisi/actionsapi/texlivemodules.py
@@ -14,9 +14,7 @@ import os
 import glob
 import shutil
 import shlex
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/actionsapi/waftools.py
+++ b/pisi/actionsapi/waftools.py
@@ -12,9 +12,7 @@
 # Standard Python Modules
 import os
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # Pisi Modules
 import pisi.context as ctx

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -14,9 +14,7 @@ import fcntl
 import re
 import fetcher
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.context as ctx

--- a/pisi/archive.py
+++ b/pisi/archive.py
@@ -20,9 +20,7 @@ import shutil
 import tarfile
 import zipfile
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # eopkg modules
 import pisi

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -11,9 +11,7 @@
 
 """Atomic package operations such as install/remove/upgrade"""
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import os
 import shutil

--- a/pisi/cli/__init__.py
+++ b/pisi/cli/__init__.py
@@ -13,11 +13,8 @@
 import sys
 import locale
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
-
 import pisi
+from pisi import translate as _
 import pisi.context as ctx
 import pisi.ui
 import pisi.util
@@ -151,10 +148,8 @@ class CLI(pisi.ui.UI):
 
         import re, tty
 
-        locale.setlocale(locale.LC_ALL, "")
         yes_expr = re.compile(locale.nl_langinfo(locale.YESEXPR))
         no_expr = re.compile(locale.nl_langinfo(locale.NOEXPR))
-        locale.setlocale(locale.LC_ALL, "C")
 
         while True:
             tty.tcflush(sys.stdin.fileno(), 0)

--- a/pisi/cli/addrepo.py
+++ b/pisi/cli/addrepo.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.api
 import pisi.cli.command as command

--- a/pisi/cli/autoremove.py
+++ b/pisi/cli/autoremove.py
@@ -13,9 +13,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/blame.py
+++ b/pisi/cli/blame.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/build.py
+++ b/pisi/cli/build.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.api

--- a/pisi/cli/check.py
+++ b/pisi/cli/check.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.api
 import pisi.cli.command as command

--- a/pisi/cli/clean.py
+++ b/pisi/cli/clean.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 

--- a/pisi/cli/command.py
+++ b/pisi/cli/command.py
@@ -14,9 +14,7 @@ import os
 import sys
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.api
 import pisi.context as ctx
@@ -53,8 +51,7 @@ class Command(object):
         l.sort()
         for name in l:
             commandcls = Command.cmd_dict[name]
-            trans = gettext.translation('pisi', fallback=True)
-            summary = trans.ugettext(commandcls.__doc__).split('\n')[0]
+            summary = _(commandcls.__doc__).split('\n')[0]
             name = commandcls.name[0]
             if commandcls.name[1]:
                 name += ' (%s)' % commandcls.name[1]
@@ -187,8 +184,7 @@ class Command(object):
 
     def help(self):
         """print help for the command"""
-        trans = gettext.translation('pisi', fallback=True)
-        print "%s: %s\n" % (self.format_name(), trans.ugettext(self.__doc__))
+        print "%s: %s\n" % (self.format_name(), _(self.__doc__))
         print self.parser.format_option_help()
 
     def die(self):

--- a/pisi/cli/configurepending.py
+++ b/pisi/cli/configurepending.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.api
 import pisi.cli.command as command

--- a/pisi/cli/deletecache.py
+++ b/pisi/cli/deletecache.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.api

--- a/pisi/cli/delta.py
+++ b/pisi/cli/delta.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.cli.command as command

--- a/pisi/cli/disablerepo.py
+++ b/pisi/cli/disablerepo.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.api

--- a/pisi/cli/emerge.py
+++ b/pisi/cli/emerge.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.cli.build as build

--- a/pisi/cli/enablerepo.py
+++ b/pisi/cli/enablerepo.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.api

--- a/pisi/cli/fetch.py
+++ b/pisi/cli/fetch.py
@@ -13,9 +13,7 @@
 import os
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/help.py
+++ b/pisi/cli/help.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli
 import pisi.cli.command as command

--- a/pisi/cli/history.py
+++ b/pisi/cli/history.py
@@ -14,9 +14,7 @@ import os
 import sys
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.api

--- a/pisi/cli/index.py
+++ b/pisi/cli/index.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/info.py
+++ b/pisi/cli/info.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/install.py
+++ b/pisi/cli/install.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/listavailable.py
+++ b/pisi/cli/listavailable.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/listcomponents.py
+++ b/pisi/cli/listcomponents.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/listinstalled.py
+++ b/pisi/cli/listinstalled.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/listnewest.py
+++ b/pisi/cli/listnewest.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/listpending.py
+++ b/pisi/cli/listpending.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/listrepo.py
+++ b/pisi/cli/listrepo.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/listsources.py
+++ b/pisi/cli/listsources.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/listupgrades.py
+++ b/pisi/cli/listupgrades.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.blacklist

--- a/pisi/cli/pisicli.py
+++ b/pisi/cli/pisicli.py
@@ -13,9 +13,7 @@
 import sys
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.cli

--- a/pisi/cli/rebuilddb.py
+++ b/pisi/cli/rebuilddb.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/remove.py
+++ b/pisi/cli/remove.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/removeorphans.py
+++ b/pisi/cli/removeorphans.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/removerepo.py
+++ b/pisi/cli/removerepo.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.api

--- a/pisi/cli/search.py
+++ b/pisi/cli/search.py
@@ -13,9 +13,7 @@
 import optparse
 import re
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/searchfile.py
+++ b/pisi/cli/searchfile.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.context as ctx

--- a/pisi/cli/updaterepo.py
+++ b/pisi/cli/updaterepo.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/cli/upgrade.py
+++ b/pisi/cli/upgrade.py
@@ -12,9 +12,7 @@
 
 import optparse
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.context as ctx

--- a/pisi/comariface.py
+++ b/pisi/comariface.py
@@ -14,9 +14,7 @@ import os
 import time
 import string
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.context as ctx

--- a/pisi/config.py
+++ b/pisi/config.py
@@ -19,9 +19,7 @@ import os
 import os.path
 import copy
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.context as ctx

--- a/pisi/configfile.py
+++ b/pisi/configfile.py
@@ -52,9 +52,7 @@ import re
 import StringIO
 import ConfigParser
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 

--- a/pisi/conflict.py
+++ b/pisi/conflict.py
@@ -12,9 +12,7 @@
 
 """conflict analyzer"""
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.relation
 

--- a/pisi/constants.py
+++ b/pisi/constants.py
@@ -14,9 +14,7 @@
 If you have a "magic" constant value this is where it should be
 defined."""
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 from pisi.util import Singleton
 

--- a/pisi/context.py
+++ b/pisi/context.py
@@ -19,9 +19,7 @@ import pisi.constants
 import pisi.signalhandler
 import pisi.ui
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 const = pisi.constants.Constants()
 sig = pisi.signalhandler.SignalHandler()

--- a/pisi/db/componentdb.py
+++ b/pisi/db/componentdb.py
@@ -11,9 +11,7 @@
 #
 
 import re
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.db.repodb

--- a/pisi/db/groupdb.py
+++ b/pisi/db/groupdb.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.db.repodb

--- a/pisi/db/installdb.py
+++ b/pisi/db/installdb.py
@@ -15,9 +15,7 @@
 
 import os
 import re
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import piksemel
 

--- a/pisi/db/itembyrepo.py
+++ b/pisi/db/itembyrepo.py
@@ -11,9 +11,7 @@
 #
 
 import gzip
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.db
 

--- a/pisi/db/repodb.py
+++ b/pisi/db/repodb.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import os
 

--- a/pisi/dependency.py
+++ b/pisi/dependency.py
@@ -12,9 +12,7 @@
 
 """dependency analyzer"""
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.relation
 import pisi.db

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -23,9 +23,7 @@ import shutil
 import time
 import urllib2
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # pisi modules
 import pisi

--- a/pisi/file.py
+++ b/pisi/file.py
@@ -20,9 +20,7 @@ like all pisi classes, it has been programmed in a non-restrictive way
 import os
 import shutil
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.uri

--- a/pisi/graph.py
+++ b/pisi/graph.py
@@ -14,9 +14,7 @@
 
 import pisi
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 class CycleException(pisi.Exception):
     def __init__(self, cycle):

--- a/pisi/history.py
+++ b/pisi/history.py
@@ -12,9 +12,7 @@
 
 import os
 import time
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.pxml.autoxml as autoxml
 import pisi.pxml.xmlfile as xmlfile

--- a/pisi/index.py
+++ b/pisi/index.py
@@ -16,9 +16,7 @@ import os
 import shutil
 import multiprocessing
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.context as ctx

--- a/pisi/metadata.py
+++ b/pisi/metadata.py
@@ -17,9 +17,7 @@ installation. Package repository also uses metadata.xml for building
 a package index.
 """
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.specfile as specfile
 import pisi.pxml.xmlfile as xmlfile

--- a/pisi/mirrors.py
+++ b/pisi/mirrors.py
@@ -13,9 +13,7 @@ import os.path
 import pisi
 import pisi.context as ctx
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 class Mirrors:
     def __init__(self, config=ctx.const.mirrors_conf):

--- a/pisi/operations/build.py
+++ b/pisi/operations/build.py
@@ -21,9 +21,7 @@ import pwd
 import grp
 import fnmatch
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.specfile

--- a/pisi/operations/check.py
+++ b/pisi/operations/check.py
@@ -13,9 +13,7 @@ import os
 import pisi
 import pisi.context as ctx
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 def file_corrupted(pfile):
     path = os.path.join(ctx.config.dest_dir(), pfile.path)

--- a/pisi/operations/emerge.py
+++ b/pisi/operations/emerge.py
@@ -12,9 +12,7 @@
 
 import sys
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.operations

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -12,9 +12,7 @@
 
 import os
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.context as ctx

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -14,9 +14,7 @@ import os
 import sys
 import zipfile
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.context as ctx

--- a/pisi/operations/remove.py
+++ b/pisi/operations/remove.py
@@ -12,9 +12,7 @@
 
 import sys
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.context as ctx

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -12,9 +12,7 @@
 
 import sys
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.ui as ui

--- a/pisi/package.py
+++ b/pisi/package.py
@@ -14,9 +14,7 @@
 
 import os.path
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import pisi.context as ctx

--- a/pisi/pxml/autoxml.py
+++ b/pisi/pxml/autoxml.py
@@ -28,9 +28,7 @@ import StringIO
 import inspect
 import re
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # eopkg
 import pisi

--- a/pisi/pxml/xmlext.py
+++ b/pisi/pxml/xmlext.py
@@ -22,9 +22,7 @@
  this implementation uses piksemel
 """
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 import piksemel as iks

--- a/pisi/pxml/xmlfile.py
+++ b/pisi/pxml/xmlfile.py
@@ -21,9 +21,7 @@
  this implementation uses piksemel
 """
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import piksemel as iks
 

--- a/pisi/replace.py
+++ b/pisi/replace.py
@@ -10,9 +10,7 @@
 # Please read the COPYING file.
 #
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi.relation
 

--- a/pisi/scenarioapi/package.py
+++ b/pisi/scenarioapi/package.py
@@ -18,10 +18,7 @@ from pisi.scenarioapi.pspec import Pspec
 from pisi.scenarioapi.actions import Actions
 from pisi.scenarioapi.constants import *
 from pisi.scenarioapi.withops import *
-
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 class Package:
     def __init__(self, name, deps = [], cons = [], date = "2006-18-18", ver = "1.0", partOf="None"):

--- a/pisi/scenarioapi/repoops.py
+++ b/pisi/scenarioapi/repoops.py
@@ -17,9 +17,7 @@ from pisi.scenarioapi.package import Package
 from pisi.scenarioapi.withops import *
 from pisi.scenarioapi.constants import *
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 repodb = {}
 

--- a/pisi/sourcearchive.py
+++ b/pisi/sourcearchive.py
@@ -12,9 +12,7 @@
 # python standard library
 
 import os
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # pisi modules
 import pisi

--- a/pisi/specfile.py
+++ b/pisi/specfile.py
@@ -16,9 +16,7 @@
  provides read and write routines for PSPEC files.
 """
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 # standard python modules
 import os.path

--- a/pisi/uri.py
+++ b/pisi/uri.py
@@ -16,9 +16,7 @@ parsing and processing"""
 import urlparse
 import os.path
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 class URI(object):
     """URI class provides a URL parser and simplifies working with

--- a/pisi/util.py
+++ b/pisi/util.py
@@ -28,9 +28,7 @@ import operator
 import subprocess
 import unicodedata
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 class Singleton(type):
     def __init__(cls, name, bases, dict):

--- a/pisi/version.py
+++ b/pisi/version.py
@@ -12,9 +12,7 @@
 
 """version structure"""
 
-import gettext
-__trans = gettext.translation('pisi', fallback=True)
-_ = __trans.ugettext
+from pisi import translate as _
 
 import pisi
 


### PR DESCRIPTION
The previous code was everything but DRY considering the locale.
This commit deduplicates the code to call the translation function,
plus makes eopkg follow the LANG variable. The outcome is a cli output
consistent with the user's language OS-wise, and a yes/no dialog
expecting characters from the same language the dialog is written in.

The translation function (`translate`) is located into `pisi/__init__.py`. A place that sounds reasonable to me.