### PR TITLE
pisi/__init__.py: Do not crash when there are no .mo files

### DIFF
--- a/pisi/__init__.py
+++ b/pisi/__init__.py
@@ -22,7 +22,12 @@ import locale
 import gettext
 locale.setlocale(locale.LC_ALL, '')
 # You usually want to import this function with the "_" alias.
-translate = gettext.translation('pisi', languages=[locale.getlocale()[0]], fallback=True).ugettext
+try:
+    translate = gettext.translation('pisi', languages=[locale.getlocale()[0]]).ugettext
+except:
+    # No .mo files found. Just return plain English.
+    def translate(msg): return msg
+
 
 __version__ = "3.2"
 


### PR DESCRIPTION
Following commit a1f4e9cd6fab55405d28738bddc7d5c46222d4c2, eopkg crashes when solus-sc calls it via d-bus. There's no translation environment in such case. So, when no .mo files are found, just set `translate` to a parrot function.

Thanks to @Staudey and @joebonrichie for finding the bug.