### PR TITLE
Update bug URL

### DIFF
--- a/eopkg-cli
+++ b/eopkg-cli
@@ -42,7 +42,7 @@ def handle_exception(exception, value, tb):
     elif isinstance(value, pisi.Exception):
         show_traceback = True
         ui.error(_("Unhandled internal exception.\n"
-                   "Please file a bug report to <http://bugs.pardus.org.tr>."))
+                   "Please file a bug report to <https://github.com/getsolus/package-management/>."))
     elif isinstance(value, IOError) and value.errno == errno.EPIPE:
         # Ignore broken pipe errors
         sys.exit(0)

--- a/po/ca.po
+++ b/po/ca.po
@@ -105,10 +105,10 @@ msgstr "S'ha acabat el programa."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Excepció interna no gestionada.\n"
-"Si us plau, presenteu un informe d'error a <http://bugs.pardus.org.tr>."
+"Si us plau, presenteu un informe d'error a <https://github.com/getsolus/package-management/>."
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/de.po
+++ b/po/de.po
@@ -114,10 +114,10 @@ msgstr "Programm beendet."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Unbehandelte interne Ausnahme.\n"
-"Bitte erstellen Sie einen Fehler-Bericht auf <http://bugs.pardus.org.tr>."
+"Bitte erstellen Sie einen Fehler-Bericht auf <https://github.com/getsolus/package-management/>."
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/es.po
+++ b/po/es.po
@@ -115,10 +115,10 @@ msgstr "Programa terminado."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Excepción interna no prevista.\n"
-"Favor envíe un reporte de la falla<http://bugs.pardus.org.tr>."
+"Favor envíe un reporte de la falla <https://github.com/getsolus/package-management/>."
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/fr.po
+++ b/po/fr.po
@@ -106,10 +106,10 @@ msgstr "Programme terminé."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Exception interne non gérée.\n"
-"Veuillez signaler le bogue s'il vous plaît sur <http://bugs.uludag.org.tr>."
+"Veuillez signaler le bogue s'il vous plaît sur <https://github.com/getsolus/package-management/>."
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/hr.po
+++ b/po/hr.po
@@ -107,7 +107,7 @@ msgstr "Program je prekinut."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 
 #: pisi-cli:57

--- a/po/hu.po
+++ b/po/hu.po
@@ -109,10 +109,10 @@ msgstr "A program futása befejeződött."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Nem kezelt belső hiba.\n"
-"Küldjön hibabejelentést a <http://bugs.pardus.org.tr> címen."
+"Küldjön hibabejelentést a <https://github.com/getsolus/package-management/> címen."
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/it.po
+++ b/po/it.po
@@ -106,10 +106,10 @@ msgstr "Programma terminato."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Eccezione interna non gestita.\n"
-"Invia per piacere una segnalazione di un bug  su <http://bugs.pardus.org.tr>"
+"Invia per piacere una segnalazione di un bug  su <https://github.com/getsolus/package-management/>"
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/nl.po
+++ b/po/nl.po
@@ -111,10 +111,10 @@ msgstr "Programma beëindigd."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Onhandelbare interne uitzondering.\n"
-"Rapporteer deze fout op <http://bugs.pardus.org.tr>."
+"Rapporteer deze fout op <https://github.com/getsolus/package-management/>."
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/pisi.pot
+++ b/po/pisi.pot
@@ -104,7 +104,7 @@ msgstr ""
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 
 #: pisi-cli:57

--- a/po/pl.po
+++ b/po/pl.po
@@ -99,10 +99,10 @@ msgstr "Program Zakończony."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Nie obsługiwany wewnętrzny błąd.\n"
-" Prosimy zgłosić ten błąd. (http://bugs.pardus.org.tr)"
+" Prosimy zgłosić ten błąd. <https://github.com/getsolus/package-management/>"
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -105,7 +105,7 @@ msgstr "Programa finalizado."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 
 #: pisi-cli:57

--- a/po/ru.po
+++ b/po/ru.po
@@ -104,10 +104,10 @@ msgstr "Программа завершена."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Необработанное внутреннее исключение. \n"
-"Пожалуйста отправьте отчет об ошибке в <http://bugs.pardus.org.tr> ."
+"Пожалуйста отправьте отчет об ошибке в <https://github.com/getsolus/package-management/> ."
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/sv.po
+++ b/po/sv.po
@@ -105,10 +105,10 @@ msgstr "Programmet avbröts."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Ohanterat internt undantag.\n"
-"Vänligen fyll i en felrapport på <http://bugs.pardus.org.tr>."
+"Vänligen fyll i en felrapport på <https://github.com/getsolus/package-management/>."
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/tr.po
+++ b/po/tr.po
@@ -110,10 +110,10 @@ msgstr "Program sonlandırıldı."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Denetlenmeyen iç hata.\n"
-"Lütfen bu hatayı <http://hata.pardus.org.tr> adresine bildiriniz."
+"Lütfen bu hatayı <https://github.com/getsolus/package-management/> adresine bildiriniz."
 
 #: pisi-cli:57
 msgid "System error. Program terminated."

--- a/po/uk.po
+++ b/po/uk.po
@@ -105,10 +105,10 @@ msgstr "Програму перервано."
 #: pisi-cli:48
 msgid ""
 "Unhandled internal exception.\n"
-"Please file a bug report to <http://bugs.pardus.org.tr>."
+"Please file a bug report to <https://github.com/getsolus/package-management/>."
 msgstr ""
 "Ноброблено внутрішні винятки.\n"
-"Будь ласка, повідомте про ваду в <http://bugs.pardus.org.tr>."
+"Будь ласка, повідомте про ваду в <https://github.com/getsolus/package-management/>."
 
 #: pisi-cli:57
 msgid "System error. Program terminated."


### PR DESCRIPTION
The bug URL for unhandled internal exceptions still points to Pardus.
Granted it shouldn't happen too often, but we don't want to bother them with our bugs :)