### PR TITLE
Fix reverse dependencies output in `eopkg info` with local repo present

### DIFF
--- a/pisi/cli/info.py
+++ b/pisi/cli/info.py
@@ -114,14 +114,18 @@ Usage: info <package1> <package2> ... <packagen>
             else:
                 print "/" + fileinfo.path
 
-    def print_metadata(self, metadata, packagedb=None):
+    def print_metadata(self, metadata, packagedb=None, repo=None):
         if ctx.get_option('short'):
             pkg = metadata.package
             ctx.ui.formatted_output(" - ".join((pkg.name, unicode(pkg.summary))))
         else:
             ctx.ui.formatted_output(unicode(metadata.package))
             if packagedb:
-                revdeps =  [name for name, dep in packagedb.get_rev_deps(metadata.package.name)]
+                if isinstance(packagedb, pisi.db.packagedb.PackageDB):
+                    revdeps_arr = packagedb.get_rev_deps(metadata.package.name, repo)
+                else:
+                    revdeps_arr = packagedb.get_rev_deps(metadata.package.name)
+                revdeps = [name for name, dep in revdeps_arr]
                 ctx.ui.formatted_output(" ".join((_("Reverse Dependencies:"), util.strlist(revdeps))))
                 print
 
@@ -153,7 +157,7 @@ Usage: info <package1> <package2> ... <packagen>
             else:
                 ctx.ui.info(_('Installed package:'))
 
-            self.print_metadata(metadata, self.installdb)
+            self.print_metadata(metadata, self.installdb, repo)
         else:
             ctx.ui.info(_("%s package is not installed") % package)
 
@@ -164,6 +168,6 @@ Usage: info <package1> <package2> ... <packagen>
                 ctx.ui.formatted_output(_("[binary] "), noln=True, column=" ")
             else:
                 ctx.ui.info(_('Package found in %s repository:') % repo)
-            self.print_metadata(metadata, self.packagedb)
+            self.print_metadata(metadata, self.packagedb, repo)
         else:
             ctx.ui.info(_("%s package is not found in binary repositories") % package)


### PR DESCRIPTION
`eopkg info` used reverse dependencies from the first repo available
instead of the one, where the package was actually found.
This caused it to show less reverse dependencies if you have local
repository set up as the first repo in `eopkg`.

Reproduction steps using `haskell-roman-numerals` and its reverse dependency
`pandoc-crossref`:

1. Set up an empty local repository and set it as first one:
```
$ eopkg lr
Local [active]
   /var/lib/solbuild/local/eopkg-index.xml.xz
Solus [active]
   https://cdn.getsol.us/repo/unstable/eopkg-index.xml.xz
```

2. Check that reverse dependencies are computed as expected:
```
$ eopkg info haskell-roman-numerals
haskell-roman-numerals package is not installed
Package found in Solus repository:
Name                : haskell-roman-numerals, version: 0.5.1.5, release: 1
Summary             : Parsing and pretty printing of Roman numerals
Description         : Parsing and pretty printing of Roman numerals
Licenses            : BSD-3-Clause
Component           : programming.haskell
Dependencies        : glibc gmp haskell-base-unicode-symbols ghc 
Distribution        : Solus, Dist. Release: 1
Architecture        : x86_64, Installed Size: 105.00 KB, Package Size: 18.00 KB
Reverse Dependencies: haskell-roman-numerals-dbginfo haskell-roman-numerals-devel pandoc-crossref 
```

3. Copy `pandoc-crossref` eopkg from cache to local repo and update repos:
```
$ sudo cp /var/cache/eopkg/packages/pandoc-crossref-0.3.4.2-1-1-x86_64.eopkg /var/lib/solbuild/local/
$ sudo eopkg index --skip-signing /var/lib/solbuild/local/ --output /var/lib/solbuild/local/eopkg-index.xml
Building index of eopkg files under /var/lib/solbuild/local/

Adding package to index: pandoc-crossref-0.3.4.2-1-1-x86_64.eopkg               
Index file written
$ sudo eopkg update-repo -f
Updating repository: Local
Package database updated.
Updating repository: Solus
eopkg-index.xml.xz.sha1sum     (40.0  B)100%      0.00 --/- [--:--:--] [complete]
Solus repository information is up-to-date.
Updating database at any rate as requested
eopkg-index.xml.xz             (3.0 MB)100%      0.00 --/- [--:--:--] [complete]
Package database updated.
```

4. Re-check reverse dependencies:
```
$ eopkg info haskell-roman-numerals
haskell-roman-numerals package is not installed
Package found in Solus repository:
Name                : haskell-roman-numerals, version: 0.5.1.5, release: 1
Summary             : Parsing and pretty printing of Roman numerals
Description         : Parsing and pretty printing of Roman numerals
Licenses            : BSD-3-Clause
Component           : programming.haskell
Dependencies        : glibc gmp haskell-base-unicode-symbols ghc 
Distribution        : Solus, Dist. Release: 1
Architecture        : x86_64, Installed Size: 105.00 KB, Package Size: 18.00 KB
Reverse Dependencies: pandoc-crossref 
```

Notice that the reverse dependencies only list `pandoc-crossref` which
we added to local repo, but not the `haskell-roman-numerals-dbginfo` and
`haskell-roman-numerals-devel` which were there before.


After the fix the reverse dependencies remain the same at steps 1 and 4.