### PR TITLE
Update source fallback URL

### DIFF
--- a/pisi/configfile.py
+++ b/pisi/configfile.py
@@ -89,7 +89,7 @@ class BuildDefaults:
     ldflags = "-Wl,--copy-dt-needed-entries -Wl,-O1 -Wl,-z,relro -Wl,-z,now -Wl,-z,max-page-size=0x1000 -Wl,-Bsymbolic-functions -Wl,--sort-common"
     buildhelper = "ccache"
     compressionlevel = 1
-    fallback = "https://getsol.us/sources"
+    fallback = "https://sources.getsol.us/"
     ignored_build_types = ""
 
 class DirectoriesDefaults:


### PR DESCRIPTION
Sources now live at sources.getsol.us instead